### PR TITLE
Add Acme Robotics dashboard dependency

### DIFF
--- a/build.dependencies.gradle
+++ b/build.dependencies.gradle
@@ -1,6 +1,10 @@
 repositories {
     mavenCentral()
     google() // Needed for androidx
+
+    maven {
+        url = 'https://maven.brott.dev/'
+    }
 }
 
 dependencies {
@@ -13,5 +17,6 @@ dependencies {
     implementation 'org.firstinspires.ftc:FtcCommon:11.0.0'
     implementation 'org.firstinspires.ftc:Vision:11.0.0'
     implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'com.acmerobotics.dashboard:dashboard:0.5.0'
 }
 


### PR DESCRIPTION
Added the 'com.acmerobotics.dashboard:dashboard:0.5.0' dependency and its Maven repository to support dashboard features in the project.

fixed #2 