### PR TITLE
Commented spindexer classes

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Firmware/Systems/Spindexer.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Firmware/Systems/Spindexer.java
@@ -34,8 +34,7 @@ public class Spindexer {
     private double ejectorInPos = 0.371; // Position of the ejector when retracted.
     private boolean calibrating = false; // Indicates if the spindexer is in calibration mode.
     private double calibrationTimeout = 1.2; // Timeout duration for calibration in seconds.
-
-    private Telemetry telemetry;
+    private Telemetry telemetry; // telemetry instance stored from constructor, helps for debugging and quick testing. Not required for base function but is still useful
     /**
      * Constructor initializes the spindexer components.
      * @param hardwareMap Hardware map to retrieve hardware instances.
@@ -65,12 +64,9 @@ public class Spindexer {
             }
         }
             paddleServo.update(); // Updates the spindexer servo position.
-        telemetry.addData("calibrating", calibrating);
-        telemetry.addData("spindexer runtime", runtime.seconds());
-        telemetry.addData("slot in intake", getCurrentIndexInIntake());
     }
 
-//    public void prepColor(COLORS color){ - Not needed for scrimmage - Tobin 11/6
+//    public void prepColor(COLORS color){ - Not needed for scrimmage - Tobin 11/6 - Should work on this soon - Tobin 11/26
 //        if (color == COLORS.NONE) {
 //            return;
 //        }
@@ -170,11 +166,19 @@ public class Spindexer {
         }
     }
 
+    /**
+     * Commands the spindexer paddle to turn to a specific degree of rotation
+     * @param degree - degrees counter clockwise from the init position
+     */
     public void setSpindexerPos(double degree){
         if (ejecting) return;
         paddleServo.setSpindexerPosition(degree);
     }
 
+    /**
+     * Returns the current rotation that is provided by the spindexer encoder
+     * @return degrees of rotation
+     */
     public double getEncoderPosition(){
         return paddleServo.getEncoderPosition();
     }


### PR DESCRIPTION
This pull request primarily removes telemetry debugging code from the `Spindexer` and `SpindexerServoFirmware` classes, streamlining their implementation for production use. It also adds documentation for new and existing methods, and makes minor improvements to comments for clarity. The changes focus on cleaning up unnecessary code and improving maintainability.

fixes #47  and fixes #48 
### Telemetry and Debug Code Removal

* Removed all telemetry debug output and related variables from `SpindexerServoFirmware`, including the `telemetry` field and `savedSlotDebug`, as well as calls to `telemetry.addData` in `update()` and `setSpindexerSlot()` methods. (`[[1]](diffhunk://#diff-8c392683228b82d97e5fab15e54e420e43ca69ad5e0193ce4708f1827dad3bc5R27-L38)`, `[[2]](diffhunk://#diff-8c392683228b82d97e5fab15e54e420e43ca69ad5e0193ce4708f1827dad3bc5L50)`, `[[3]](diffhunk://#diff-8c392683228b82d97e5fab15e54e420e43ca69ad5e0193ce4708f1827dad3bc5L70-L77)`, `[[4]](diffhunk://#diff-8c392683228b82d97e5fab15e54e420e43ca69ad5e0193ce4708f1827dad3bc5L101)`)
* Removed telemetry debug output from the `updateSpindexer()` method in `Spindexer`, cleaning up runtime and calibration status reporting. (`[TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Firmware/Systems/Spindexer.javaL68-R69](diffhunk://#diff-448a1fca3afa7340da994df893c1a395208d13d6843f435d19873756db78e977L68-R69)`)

### Documentation and Comment Improvements

* Added JavaDoc comments for the new `setSpindexerPos(double degree)` and `getEncoderPosition()` methods in `Spindexer`, clarifying their purpose and usage. (`[TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Firmware/Systems/Spindexer.javaR169-R181](diffhunk://#diff-448a1fca3afa7340da994df893c1a395208d13d6843f435d19873756db78e977R169-R181)`)
* Improved inline comments for the `telemetry` field in `Spindexer` to clarify its optional role for debugging. (`[TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Firmware/Systems/Spindexer.javaL37-R37](diffhunk://#diff-448a1fca3afa7340da994df893c1a395208d13d6843f435d19873756db78e977L37-R37)`)
* Relocated and clarified the "warp speed exit tolerance" comment in `SpindexerServoFirmware` for better readability. (`[TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Firmware/Systems/SpindexerServoFirmware.javaR51-R54](diffhunk://#diff-8c392683228b82d97e5fab15e54e420e43ca69ad5e0193ce4708f1827dad3bc5R51-R54)`)

### Minor Code Organization

* Minor reordering and grouping of comments and fields for improved code readability in both classes. (`[[1]](diffhunk://#diff-8c392683228b82d97e5fab15e54e420e43ca69ad5e0193ce4708f1827dad3bc5R27-L38)`, `[[2]](diffhunk://#diff-8c392683228b82d97e5fab15e54e420e43ca69ad5e0193ce4708f1827dad3bc5R51-R54)`)

These changes help ensure the codebase is cleaner and easier to maintain, removing unnecessary debug code while retaining essential functionality.