### PR TITLE
Auto aim drift bugfix

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Firmware/DecodeBot.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Firmware/DecodeBot.java
@@ -61,7 +61,7 @@ public abstract class DecodeBot extends Robot{
         odometry = new GobildaPinpointModuleFirmware(hardwareMap, xOffset,yOffset,reset);
         trajectoryKinematics = new TrajectoryKinematics(isAuto);
         bulkSensorBucket = new BulkSensorBucket(hardwareMap);
-        driveTrain = new MecanumDriveTrain(hardwareMap, telemetry);
+        driveTrain = new MecanumDriveTrain(hardwareMap, telemetry, this.alliance);
         launcher = new Launcher(hardwareMap,telemetry);
         intake = new Intake(hardwareMap, telemetry);
         spindexer = new Spindexer(hardwareMap,telemetry,reset,isAuto);
@@ -115,39 +115,22 @@ public abstract class DecodeBot extends Robot{
     public void updateRobot(boolean holdPosition, boolean autoSpeedChange, boolean isAuto){
         odometry.updateOdometry();
 //        operatorStateMachine.updateStateMachine();
+        aprilTags.clearCache();
     }
 
     // red or blue
     public void setAlliance(String alliance){
         this.alliance = alliance;
     }
-    public void aimBasedOnTags(){
 
-        if (aprilTags.isTag(alliance)) {
-            if (!isAuto) {
-                switch (alliance) {
-                    case "red":
-                        odometry.overridePosition(aprilTags.getRobotX(), aprilTags.getRobotY(), aprilTags.getRobotAngle() - 90);
-                        break;
-                    case "blue":
-                        odometry.overridePosition(odometry.getRobotX(), odometry.getRobotY(), aprilTags.getRobotAngle() + 90);
-                        break;
-                }
-            } else {
-                switch (alliance) {
-                    case "red":
-                        odometry.overridePosition(aprilTags.getRobotX(), aprilTags.getRobotY(), aprilTags.getRobotAngle() - 0);
-                        break;
-                    case "blue":
-                        odometry.overridePosition(aprilTags.getRobotX(), aprilTags.getRobotY(), aprilTags.getRobotAngle() + 0);
-                }
-            }
+    public void updateOdometryOnTags(){
+        if (!aprilTags.isTag(alliance)) {
+           return;
         }
+        odometry.overridePosition(aprilTags.getRobotX(), aprilTags.getRobotY(), aprilTags.getRobotAngle());
+    }
+    public void aimAtGoal(){
         double bearingToGoal = aprilTags.getBearingToTag(alliance, isAuto, odometry.getRobotX(),odometry.getRobotY());
-        if (bearingToGoal == -1000) return;
-        telemetry.addData("aprilTagAngle",bearingToGoal );
-        telemetry.addData("actualAngle",aprilTags.getRobotAngle());
-
         rotationControl.setTargetAngle(bearingToGoal);
     }
     public void setLauncherBasedOnTags(){

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Firmware/Systems/AprilTag.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Firmware/Systems/AprilTag.java
@@ -201,16 +201,12 @@ public class AprilTag {
 
     // the getBearingToTag is used to turn the robot so it is facing the center of the tag
     public double getBearingToTag(String mode, Boolean isAuto, double x, double y){
-
-        locateAprilTags(mode);
-        if (aprilTagID == 0) return -1000;
         double angle;
-
         double posX = x;
         double posY = y;
         double goalX = 0;
         double goalY = 0;
-        double coordinate_correction_offset = 0;
+        double coordinate_correction_offset = 90;
         double FLYWHEEL_OFFSET = 0;
 
 
@@ -218,19 +214,11 @@ public class AprilTag {
             case "red":
                 goalX = -67.2;
                 goalY = 60;
-                coordinate_correction_offset = 0;
-                if (isAuto){
-                    coordinate_correction_offset += 90;
-                }
                 FLYWHEEL_OFFSET = Math.toDegrees(Math.atan(5/123.5));
                 break;
             case "blue":
                 goalX = -60.2;
                 goalY = -60;
-                coordinate_correction_offset = 180;
-                if (isAuto){
-                    coordinate_correction_offset -= 90;
-                }
                 FLYWHEEL_OFFSET = Math.toDegrees(Math.atan(5/123.5));
                 break;
         }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Firmware/Systems/MecanumDriveTrain.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Firmware/Systems/MecanumDriveTrain.java
@@ -5,10 +5,14 @@ import com.qualcomm.robotcore.hardware.HardwareMap;
 
 import org.firstinspires.ftc.robotcore.external.Telemetry;
 import org.firstinspires.ftc.robotcore.external.navigation.AngleUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.ArrayList;
 import java.util.List;
 
 public class MecanumDriveTrain {
+    private static final Logger log = LoggerFactory.getLogger(MecanumDriveTrain.class);
     DcMotor motorFL;
     DcMotor motorFR;
     DcMotor motorBL;
@@ -20,6 +24,7 @@ public class MecanumDriveTrain {
     private double turnPriority = 1.0;
 
     private Telemetry telemetry;
+    private String alliance = "red";
     /**
      * constructor for mecanum drive train
      * -assigns motors from hardware map
@@ -27,8 +32,9 @@ public class MecanumDriveTrain {
      * -sets zero power behavior to brake
      * @param hardwareMap hardware map of robot
      */
-    public MecanumDriveTrain(HardwareMap hardwareMap, Telemetry telemetry) {
+    public MecanumDriveTrain(HardwareMap hardwareMap, Telemetry telemetry, String alliance) {
         this.telemetry = telemetry;
+        this.alliance = alliance;
         motorFL = hardwareMap.get(DcMotor.class, "fl");
         motorFR = hardwareMap.get(DcMotor.class, "fr");
         motorBL = hardwareMap.get(DcMotor.class, "bl");
@@ -97,6 +103,14 @@ public class MecanumDriveTrain {
      * @return
      */
     private List<Double> calculateFieldCentricDriving(double forwardPower, double sidewaysPower,double robotHeading){
+        switch (alliance){
+            case "red":
+                robotHeading+=90;
+                break;
+            case "blue":
+                robotHeading -= 90;
+                break;
+        }
         double fwdPower = forwardPower * Math.cos(-AngleUnit.DEGREES.toRadians(robotHeading)) + sidewaysPower * Math.sin(-AngleUnit.DEGREES.toRadians(robotHeading));
         double sidePower = -forwardPower * Math.sin(-AngleUnit.DEGREES.toRadians(robotHeading)) + sidewaysPower * Math.cos(-AngleUnit.DEGREES.toRadians(robotHeading));
         List<Double> power = new ArrayList<Double>();

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Opmodes/Autonomous/BlueBeaver.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Opmodes/Autonomous/BlueBeaver.java
@@ -29,11 +29,11 @@ public class BlueBeaver extends BaseAuto {
         }else{
             robot.chill(true,0.3);
         }
-        robot.aimBasedOnTags();
+        robot.aimAtGoal();
         robot.setLauncherBasedOnTags();
 
         robot.chill(true,0.3);
-        robot.aimBasedOnTags();
+        robot.aimAtGoal();
         autonomousLaunching(motifId);
     }
 
@@ -54,7 +54,7 @@ public class BlueBeaver extends BaseAuto {
         robot.setAlliance("blue");
         //This is the position that the robot moves to to shoot the first three balls
         motifId = 0;
-        robot.aimBasedOnTags();
+        robot.aimAtGoal();
         robot.chill(true,0.2);
         sortedLaunch(false, true);
         detectMotifWhileMoveTo(-39,-40,-210,10);

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Opmodes/Autonomous/RedBeaver.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Opmodes/Autonomous/RedBeaver.java
@@ -29,11 +29,11 @@ public class RedBeaver extends BaseAuto {
         }else{
             robot.chill(true,0.3);
         }
-        robot.aimBasedOnTags();
+        robot.aimAtGoal();
         robot.setLauncherBasedOnTags();
 
         robot.chill(true,0.3);
-        robot.aimBasedOnTags();
+        robot.aimAtGoal();
         autonomousLaunching(motifId);
 //
     }
@@ -53,7 +53,7 @@ public class RedBeaver extends BaseAuto {
         robot.chill(false,0.2);
         //This is the position that the robot moves to to shoot the first three balls
         motifId = 0;
-        robot.aimBasedOnTags();
+        robot.aimAtGoal();
         robot.chill(true,0.2);
         sortedLaunch(false, true);
         detectMotifWhileMoveTo(-39,40,210,10);

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Opmodes/Teleop/BlueScrimmageTeleop.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Opmodes/Teleop/BlueScrimmageTeleop.java
@@ -53,7 +53,7 @@ public class BlueScrimmageTeleop extends BaseTeleOp {
                 robot.intake.setIntakePower(0);
             }
             if (gamepad1.cross){
-                robot.aimBasedOnTags();
+                robot.aimAtGoal();
             }else{
                 robot.rotationControl.changeTargetByJoystick(gamepad1.right_stick_x,robot.odometry.getRobotAngle());
             }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Opmodes/Teleop/BlueTeleop.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Opmodes/Teleop/BlueTeleop.java
@@ -112,10 +112,12 @@ public class BlueTeleop extends BaseTeleOp {
 
                 robot.operatorStateMachine.updateStateMachine();
             }
-
-            if (gamepad1.cross){
-                robot.aimBasedOnTags();
-                robot.driveTrain.setTurnPriority(1.7);
+            if (gamepad1.left_bumper){
+                robot.updateOdometryOnTags();
+            }
+            if (gamepad1.left_trigger > 0.2){
+                robot.aimAtGoal();
+                robot.driveTrain.setTurnPriority((gamepad1.left_trigger/2)+0.8);
             }else{
                 robot.rotationControl.changeTargetByJoystick(gamepad1.right_stick_x,robot.odometry.getRobotAngle());
                 robot.driveTrain.setTurnPriority(1.0);

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Opmodes/Teleop/RedScrimmageTeleop.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Opmodes/Teleop/RedScrimmageTeleop.java
@@ -55,7 +55,7 @@ public class RedScrimmageTeleop extends BaseTeleOp {
                 robot.intake.setIntakePower(0);
             }
             if (gamepad1.cross){
-                robot.aimBasedOnTags();
+                robot.aimAtGoal();
             }else{
                 robot.rotationControl.changeTargetByJoystick(gamepad1.right_stick_x,robot.odometry.getRobotAngle());
             }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Opmodes/Teleop/RedTeleop.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Opmodes/Teleop/RedTeleop.java
@@ -114,10 +114,12 @@ public class RedTeleop extends BaseTeleOp {
 
                 robot.operatorStateMachine.updateStateMachine();
             }
-
-            if (gamepad1.cross){
-                robot.aimBasedOnTags();
-                robot.driveTrain.setTurnPriority(1.0);
+            if (gamepad1.left_bumper){
+                robot.updateOdometryOnTags();
+            }
+            if (gamepad1.left_trigger > 0.2){
+                robot.aimAtGoal();
+                robot.driveTrain.setTurnPriority((gamepad1.left_trigger/2)+0.8);
             }else{
                 robot.rotationControl.changeTargetByJoystick(gamepad1.right_stick_x,robot.odometry.getRobotAngle());
                 robot.driveTrain.setTurnPriority(1.0);

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Opmodes/Testing/ApriltagLocalizationTesting.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Opmodes/Testing/ApriltagLocalizationTesting.java
@@ -24,7 +24,7 @@ public class ApriltagLocalizationTesting extends BaseTeleOp {
                 telemetry.addData("aprilY", robot.aprilTags.getRobotY());
                 telemetry.addData("aprilYaw", robot.aprilTags.getRobotAngle());
             }
-            robot.aimBasedOnTags();
+            robot.aimAtGoal();
             robot.bulkSensorBucket.clearCache();
             robot.driveTrain.setDrivePower(0, 0, robot.rotationControl.getOutputPower(robot.odometry.getRobotAngle()), robot.odometry.getRobotAngle());
             robot.aprilTags.clearCache();


### PR DESCRIPTION
fixes #104 
fixes #96 

Fixed the problem with infinate rotation by clearing the AprilTag cache correctly and only syncing odometry with tags with a seperate button.