### PR TITLE
Third Artifact Timeout implementation

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Firmware/OperatorStateMachine.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Firmware/OperatorStateMachine.java
@@ -254,7 +254,8 @@ public class OperatorStateMachine {
                 runtime.reset();
                 launchTimeOuting = true;
             }
-            if (runtime.seconds() >= launcherTimeOut) {
+            if (runtime.seconds() >= launcherTimeOut && launchTimeOuting == true) {
+                launchTimeOuting = false;
                 moveToState(State.IDLE);
                 launcher.setGatePosition(false);
             }


### PR DESCRIPTION
Introduces a timeout mechanism before transitioning to the IDLE state and closing the launcher gate. This helps ensure a delay of 0.5 seconds after launching is complete before resetting the state.