### PR TITLE
Tighten AprilTag filter and error threshold

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Firmware/Systems/AprilTag.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Firmware/Systems/AprilTag.java
@@ -51,7 +51,8 @@ public class AprilTag {
     public static double cameraZ = 350;
 
     private double x, y, angle = 0;
-    public static double filterScalar = 0.1;
+    // Filter scalar, the amount we rely on the april tags
+    public static double filterScalar = 0.001;
 
 
 
@@ -251,7 +252,8 @@ public class AprilTag {
         return true;
     }
 
-    public static double disallowedErrorThreshold = 20;
+    // how wrong the aprilTag filtered values are allowed to be in order to be used.
+    public static double disallowedErrorThreshold = 5;
     /**
      * Scales a value with a common filter algorithm
      * @param currentValue the current value of what we think it is


### PR DESCRIPTION
Adjust AprilTag.java filter settings: reduce filterScalar from 0.1 to 0.001 to lower reliance on tag readings, and tighten disallowedErrorThreshold from 20 to 5 to require smaller allowed error. Added brief inline comments clarifying each parameter's purpose.
