### PR TITLE
Propagate alliance and fix heading rotation

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Firmware/DecodeBot.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Firmware/DecodeBot.java
@@ -122,6 +122,7 @@ public abstract class DecodeBot extends Robot{
     // red or blue
     public void setAlliance(String alliance){
         this.alliance = alliance;
+        driveTrain.setAlliance(alliance);
     }
 
     public void updateOdometryOnTags(boolean hardUpdate){

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Firmware/Systems/MecanumDriveTrain.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Firmware/Systems/MecanumDriveTrain.java
@@ -92,6 +92,9 @@ public class MecanumDriveTrain {
     public double getTurnPriority(){
         return turnPriority;
     }
+    public void setAlliance(String alliance){
+        this.alliance = alliance;
+    }
 
     /**
      * Calculates Field Centic Driving (code that allows the driver controls to
@@ -105,10 +108,10 @@ public class MecanumDriveTrain {
     private List<Double> calculateFieldCentricDriving(double forwardPower, double sidewaysPower,double robotHeading){
         switch (alliance){
             case "red":
-                robotHeading+=90;
+                robotHeading-=90;
                 break;
             case "blue":
-                robotHeading -= 90;
+                robotHeading += 90;
                 break;
         }
         double fwdPower = forwardPower * Math.cos(-AngleUnit.DEGREES.toRadians(robotHeading)) + sidewaysPower * Math.sin(-AngleUnit.DEGREES.toRadians(robotHeading));


### PR DESCRIPTION
Call driveTrain.setAlliance when DecodeBot.setAlliance is invoked and add a setAlliance method to MecanumDriveTrain. Adjust the 90° offset logic in calculateFieldCentricDriving (red now subtracts 90°, blue now adds 90°) to correct field-centric heading rotation for each alliance.

fixes #136 