### PR TITLE
Update autonomous routines, odometry, timeouts

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Firmware/DecodeBot.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Firmware/DecodeBot.java
@@ -60,7 +60,7 @@ public abstract class DecodeBot extends Robot{
         this.isAuto = isAuto;
 
         //Creating the classes as objects for future use
-        odometry = new GobildaPinpointModuleFirmware(hardwareMap, telemetry,xOffset,yOffset,reset);
+        odometry = new GobildaPinpointModuleFirmware(hardwareMap, telemetry,xOffset,yOffset,resetOdemetry);
         trajectoryKinematics = new TrajectoryKinematics(isAuto, telemetry);
         bulkSensorBucket = new BulkSensorBucket(hardwareMap);
         driveTrain = new MecanumDriveTrain(hardwareMap, telemetry, this.alliance);
@@ -118,7 +118,7 @@ public abstract class DecodeBot extends Robot{
     public void updateRobot(boolean holdPosition, boolean autoSpeedChange, boolean isAuto){
         intake.updateIntake();
         odometry.updateOdometry();
-        lifter.update();
+//        lifter.update();
 //        operatorStateMachine.updateStateMachine();
         aprilTags.clearCache();
     }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Firmware/OperatorStateMachine.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Firmware/OperatorStateMachine.java
@@ -44,13 +44,13 @@ public class OperatorStateMachine {
     private boolean prepping = false;
     private boolean launched = false;
     public static double launchingTimeout = 0.0;
-    public static double sortingTimeout = 0.1;
+    public static double sortingTimeout = 0.12;
     private ElapsedTime runtime = null;
     private Gamepad gamepad2 = null;
     private ElapsedTime launchTimer = null;
     private ElapsedTime preppingTimer = null;
     private TrajectoryKinematics trajectoryKinematics = null;
-    public static double launcherTimeOut = 0.2;
+    public static double launcherTimeOut = 0.25;
     private boolean launchTimeOuting = false;
 
     // Will Trigger the transition from one state to the next

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Opmodes/Autonomous/RedFar6And9.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Opmodes/Autonomous/RedFar6And9.java
@@ -1,30 +1,41 @@
 package org.firstinspires.ftc.teamcode.Opmodes.Autonomous;
 
+import com.qualcomm.robotcore.eventloop.opmode.Autonomous;
+
 import org.firstinspires.ftc.teamcode.Firmware.OperatorStateMachine;
 import org.firstinspires.ftc.teamcode.Firmware.Systems.Spindexer;
 import org.firstinspires.ftc.teamcode.Firmware.Systems.SpindexerColorSensor;
 import org.firstinspires.ftc.teamcode.Opmodes.BaseAuto;
-
+@Autonomous
 public class RedFar6And9 extends BaseAuto {
-    private void sortedLaunch(boolean finalLaunch, boolean firstLaunch) {
+    private void sortedLaunchClose(boolean finalLaunch, boolean firstLaunch) {
         if (!firstLaunch) {
-            robot.autoMoveTo(52,19,170,2);
+            robot.autoMoveTo(-15.5, 30, 195, 25);
         }
+//        robot.autoMoveTo(0, 40, 135, 2);
+        //The robot moves to the launch zone and it launches the three balls
         if (!finalLaunch) {
-            if (firstLaunch) {
-                robot.autoMoveTo(52, 19, 170, 8);
-            } else {
-                robot.autoMoveTo(52, 19, 170, 8);
+            if (firstLaunch){
+                robot.autoMoveTo(-15.5, 19, 132, 8);
+            }else{
+                robot.autoMoveTo(-15.5, 19, 134, 8);
             }
 
-        } else {
-            robot.autoMoveTo(52, 19, 170, 8);
+        }else{
+            robot.autoMoveTo(-35, 18, 116, 4);
         }
-        if (!firstLaunch) {
-            robot.chill(true, 0.8);
-        } else {
-            robot.chill(true, 0.3);
-        }
+
+        robot.aimAtGoal();
+        robot.setLauncherBasedOnTags();
+
+        robot.chill(true,0.3);
+        robot.aimAtGoal();
+        autonomousLaunching(motifId);
+    }
+    private void sortedLaunchFar(boolean finalLaunch, boolean firstLaunch) {
+        robot.autoMoveTo(52.3, 18.9, 162.9, 8);
+        robot.chill(true, 0.3);
+
         robot.aimAtGoal();
         robot.setLauncherBasedOnTags();
 
@@ -43,44 +54,82 @@ public class RedFar6And9 extends BaseAuto {
 
         waitForStart();
         //This is the starting location of the robot
-        robot.odometry.overridePosition(64,13,180);
+        robot.odometry.overridePosition(62.7,31.2,90);
         robot.spindexer.setIndexOffset(Spindexer.INDEX_TYPE.NONE);
         robot.chill(false,0.2);
         //This is the position that the robot moves to to shoot the first three balls
         motifId = 0;
+        robot.launcher.revFlywheel();
         robot.aimAtGoal();
-        robot.chill(true,0.2);
-        sortedLaunch(false, true);
+        robot.chill(true,0.0);
+        sortedLaunchFar(false, true);
         //Move to corner set
-        //robot.autoMoveTo(,,,);
-        //Intake
+        robot.autoMoveTo(56,23,200,6);
         robot.operatorStateMachine.moveToState(OperatorStateMachine.State.INTAKE);
-        //Move to launch zone
-        //robot.autoMoveTo(,,,);
-        //Launch
-        //robot.autoMoveTo(,,,);
-        robot.operatorStateMachine.moveToState(OperatorStateMachine.State.LAUNCH);
-        //Intake 2nd set
-        //robot.autoMoveTo(,,,);
+        robot.autoMoveTo(59,51,270,6);
+        robot.autoMoveTo(63,58.1,270,3);
+        robot.chill(true,0.45);
+
+        //Moves to the mid zone and launches the second set
+        robot.autoMoveTo(51.3,27.2,265,5);
+        robot.launcher.revFlywheel();
+        robot.autoMoveTo(20,18.2,210,8);
+        robot.launcher.revFlywheel();
+        robot.autoMoveTo(-8.6,18.2,170,8);
+        // Launch the second set
+
+        robot.launcher.revFlywheel();
+        robot.chill(true,0.2);
+
+        robot.aimAtGoal();
+        sortedLaunchClose(false,true);
         robot.operatorStateMachine.moveToState(OperatorStateMachine.State.INTAKE);
-        //Open gate
-        //robot.autoMoveTo(,,,);
-        //Launch 2nd from close zone
-        //robot.autoMoveTo(,,,);
-        robot.operatorStateMachine.moveToState(OperatorStateMachine.State.LAUNCH);
-        //Intake closest set
-        //robot.autoMoveTo(,,,);
+        robot.chill(true,0.2);
+        robot.autoMoveTo(-12,26,272,3);
+        robot.pathFollowing.setFollowSpeed(0.6);
+        robot.autoMoveTo(-12.5,50.8,270,4);
+
+        //The robot bumps the gate
+        robot.autoMoveTo(-15.1,42.2,270,3);
+        robot.pathFollowing.setFollowSpeed(1);
+        robot.autoMoveTo(-5,44,180,2.5);
+        robot.launcher.revFlywheel();
+        robot.autoMoveTo(-3,53.3,180,3);
+        chillAndDetect(true,0.55);
+        sortedLaunchClose(false, false);
+
+        //The robot moves to the place to intake the balls
         robot.operatorStateMachine.moveToState(OperatorStateMachine.State.INTAKE);
-        //Launch
-        //robot.autoMoveTo(,,,);
-        robot.operatorStateMachine.moveToState(OperatorStateMachine.State.LAUNCH);
-        //Intake 3rd set
-        //robot.autoMoveTo(,,,);
+        robot.autoMoveTo(-8,46,176,6);
+
+        robot.launcher.revFlywheel();
+        robot.autoMoveTo(15,46,177,3);
+
+
+
+        robot.chill(true, 0.2);
+//
+        sortedLaunchClose(false, false);
+//
+//        // sorted cycle 2
+//
+//        //The robot moves to the place to intake the balls
         robot.operatorStateMachine.moveToState(OperatorStateMachine.State.INTAKE);
-        //Launch from far
-        //robot.autoMoveTo(,,,);
-        robot.operatorStateMachine.moveToState(OperatorStateMachine.State.LAUNCH);
-        //move off line
-        //robot.autoMoveTo(,,,);
+        robot.autoMoveTo(18.5,44,175,4);
+        robot.chill(true,0.2);
+        robot.launcher.revFlywheel();
+        robot.autoMoveTo(32.3,44,175,4);
+        robot.chill(true, 0.2);
+
+
+//
+        sortedLaunchFar(true,false);
+//
+//        // sorted cycle 3
+//
+////      park off of launch line and close to the gate to clear the classifier at teleop start
+        robot.autoMoveTo(30,22,170,2);
+        robot.chill(true,0.2);
+
     }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Opmodes/Testing/odometryTesting.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Opmodes/Testing/odometryTesting.java
@@ -5,7 +5,7 @@ import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
 import org.firstinspires.ftc.teamcode.Opmodes.BaseTeleOp;
 
 @TeleOp
-@Disabled
+//@Disabled
 public class odometryTesting extends BaseTeleOp {
     @Override
     public void runOpMode() throws InterruptedException {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Resources/TrajectoryKinematics.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Resources/TrajectoryKinematics.java
@@ -129,8 +129,12 @@ public class TrajectoryKinematics {
         switch (mode) {
             case "red":
                 // These are empirically set goal coordinates (inches) for the red alliance
-                tempGoalY = 60;
+                tempGoalY = 52;
                 tempGoalX = -64.2;
+                if (isAuto){
+                    tempGoalY = 50;
+                    tempGoalX = -60.2;
+                }
                 // Geometry: Math.atan(5/123.5) represents a small angular offset due to
                 // the flywheel's vertical/horizontal displacement relative to the robot
                 // center. The numbers are empirical and should be documented in design notes.
@@ -166,8 +170,9 @@ public class TrajectoryKinematics {
                 switch (mode) {
             case "red":
                 // These are empirically set goal coordinates (inches) for the red alliance
-                tempGoalY = 58;
-                tempGoalX = -66.2;
+                tempGoalY = 54;
+                tempGoalX = -62.2;
+
                 break;
             case "blue":
                 // Empirically determined goal coordinates (inches) for the blue alliance


### PR DESCRIPTION
Refactor autonomous behaviors and tune supporting systems: adjust odometry instantiation parameter name, comment out lifter.update call, and tweak OperatorStateMachine timing constants (sortingTimeout and launcherTimeOut). Major changes to RedFar6And9: add @Autonomous, rename/rework sortedLaunch into close/far variants, revise many autoMoveTo coordinates and sequences, add launcher rev/aim calls, adjust odometry start position and spindexer index offset, tweak path following speeds and chill timings to improve launch/intake cycles and parking. Re-enable the odometry testing TeleOp (uncomment @Disabled). Update TrajectoryKinematics goal coordinates for red (and auto) modes to new empirical values.

fixes #122 