### PR TITLE
Require launcher up to speed before launching; fix indent

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Firmware/OperatorStateMachine.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Firmware/OperatorStateMachine.java
@@ -317,7 +317,7 @@ public class OperatorStateMachine {
             }
         }
 
-        if (spindexer.isAtRest() && shotsRemaining > 0 && !launchStalled){
+        if (spindexer.isAtRest() && shotsRemaining > 0 && !launchStalled && launcher.isUpToSpeed()){
             spinning = false;
             if (shouldSort){
                 launchStalled = true;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Opmodes/Testing/SWEEP/SWEEPFullAutoTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Opmodes/Testing/SWEEP/SWEEPFullAutoTest.java
@@ -57,7 +57,7 @@ public class SWEEPFullAutoTest extends BaseAuto {
         robot.SWEEP.computeSplines();
         robot.odometry.overridePosition(64,16,90);
         robot.SWEEP.startPath();
-        while (opModeIsActive() && !robot.SWEEP.isPathComplete()){
+            while (opModeIsActive() && !robot.SWEEP.isPathComplete()){
             robot.odometry.updateOdometry();
             robot.SWEEP.update(robot.odometry.getOdometryPacket());
             //TODO: update robot system loops


### PR DESCRIPTION
Add a guard in OperatorStateMachine so the spindexer only proceeds when launcher.isUpToSpeed() is true, preventing premature sorting/spin stalls if the launcher hasn't reached speed. Also adjust indentation in SWEEPFullAutoTest (while loop) for consistent formatting.
